### PR TITLE
Sort hashed data before testing its order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ fn deduct(from: &CharCounts, counts: &CharCounts) -> Option<CharCounts> {
 /// # use anagram::anagrams;
 /// let dictionary = vec!("pet", "er");
 /// let mut phrases = anagrams("peter", dictionary.into_iter());
+/// phrases.sort(); // hashing order can be nondeterministic
 /// assert_eq!(phrases, vec!["er pet", "pet er"]);
 /// ```
 pub fn anagrams<'word>(


### PR DESCRIPTION
This is the implication of [RandomState](https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html) and [HashMap::iter](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.iter).